### PR TITLE
Use typed array to boost performance by 50%

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var Buffer = require('buffer').Buffer;
 
-var CRC_TABLE = new Int32Array([
+var CRC_TABLE = [
   0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419,
   0x706af48f, 0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4,
   0xe0d5e91e, 0x97d2d988, 0x09b64c2b, 0x7eb17cbd, 0xe7b82d07,
@@ -53,7 +53,10 @@ var CRC_TABLE = new Int32Array([
   0xcdd70693, 0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8,
   0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b,
   0x2d02ef8d
-]);
+];
+
+if (typeof Int32Array !== 'undefined')
+  CRC_TABLE = new Int32Array(CRC_TABLE);
 
 function bufferizeInt(num) {
   var tmp = Buffer(4);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": ">=0.8"
+    "node": "*"
   }
 }


### PR DESCRIPTION
Haven't tested on node 0.6, but added guard in package.json for that
