### PR TITLE
Add MIT license to package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License
+
 Copyright (c) 2013 Brian J. Brennan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "name": "buffer-crc32",
   "description": "A pure javascript CRC32 algorithm that plays nice with binary data",
   "version": "0.2.3",
+  "licenses" : [
+    {
+      "type" : "MIT",
+      "url" : "https://github.com/caolan/async/raw/master/LICENSE"
+    }
+  ],
   "contributors": [
     {
       "name": "Vladimir Kuznetsov",


### PR DESCRIPTION
Allows license to be read programatically.
