### PR TITLE
use `new` with Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function bufferizeInt(num) {
 
 function _crc32(buf, previous) {
   if (!Buffer.isBuffer(buf)) {
-    buf = Buffer(buf);
+    buf = new Buffer(buf);
   }
   if (Buffer.isBuffer(previous)) {
     previous = previous.readUInt32BE(0);


### PR DESCRIPTION
Fixes DeprecationWarning in Node 7:

```
(node:84948) DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.
```

See issue #14.