### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - 10
   - 12
-  - 4
-  - 6
+  - 14
+  - 8
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
+  - 10
+  - 12
   - 4
   - 6
 notifications:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.
