### PR TITLE
chore: Explicit module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "test": "./node_modules/.bin/tap tests/*.test.js"
   },
+  "type": "commonjs",
   "dependencies": {},
   "devDependencies": {
     "tap": "~0.2.5"


### PR DESCRIPTION
Node 21+ recommends explicitly setting module type for packages, because that makes imports faster when dynamic CJS/ESM resolution is enabled.