### PR TITLE
Add benchmark comparing performance of this package with node:zlib.crc32

### DIFF
--- a/benchmarks/crc.bench.js
+++ b/benchmarks/crc.bench.js
@@ -1,0 +1,24 @@
+const bench = require('micro-bmark');
+const crc32 = require('..');
+const zlib = require('node:zlib');
+
+const smallBuffer = Buffer.from([0, 1, 2, 3, 4, 5]);
+const largeBuffer = Buffer.alloc(100000);
+
+// Do a few iterations first to get insight into the performance before JIT optimization.
+bench.mark(' few iterations, small buffer, native', 10, () => zlib.crc32(smallBuffer));
+bench.mark(' few iterations, small buffer, js    ', 10, () => crc32.unsigned(smallBuffer));
+bench.mark(' few iterations, large buffer, native', 10, () => zlib.crc32(largeBuffer));
+bench.mark(' few iterations, large buffer, js    ', 10, () => crc32.unsigned(largeBuffer));
+
+// Run many iterations to warm up the JIT optimization.
+bench.mark('(warm up. ignore)', 10000, () => zlib.crc32(smallBuffer));
+bench.mark('(warm up. ignore)', 10000, () => crc32.unsigned(smallBuffer));
+bench.mark('(warm up. ignore)', 10000, () => zlib.crc32(largeBuffer));
+bench.mark('(warm up. ignore)', 10000, () => crc32.unsigned(largeBuffer));
+
+// Then collect data once the optimization has presumably reached a steady state.
+bench.mark('many iterations, small buffer, native', 20000, () => zlib.crc32(smallBuffer));
+bench.mark('many iterations, small buffer, js    ', 20000, () => crc32.unsigned(smallBuffer));
+bench.mark('many iterations, large buffer, native', 20000, () => zlib.crc32(largeBuffer));
+bench.mark('many iterations, large buffer, js    ', 20000, () => crc32.unsigned(largeBuffer));

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
   },
   "scripts": {
     "test": "tap tests/*.test.js --reporter classic",
+    "benchmark": "node benchmarks/crc.bench.js",
     "build": "npx unbuild@2.0.0 && npx cpy-cli index.d.ts dist --rename=index.d.cts && npx cpy-cli index.d.ts dist --rename=index.d.mts",
     "prepublishOnly": "npm run build",
     "format": "prettier --write --log-level warn \"**/*.{json,md,js}\""
   },
   "dependencies": {},
   "devDependencies": {
+    "micro-bmark": "^0.3.1",
     "prettier": "^3.2.4",
     "tap": "~11.1.5"
   },


### PR DESCRIPTION
Mentioned in https://github.com/brianloveswords/buffer-crc32/issues/34#issuecomment-2424754251

Here's my manually formatted table of data:
```
 few iterations, small buffer, native x   187,828 ops/sec @   5μs/op ± 155.19% (min: 472ns, max:  40μs)
 few iterations, small buffer, js     x    77,053 ops/sec @  12μs/op ± 120.51% (min: 891ns, max:  63μs)
-------------------------------------------------------------------------------------------------------
 few iterations, large buffer, native x    46,038 ops/sec @  21μs/op ±  17.43% (min:  19μs, max:  37μs)
 few iterations, large buffer, js     x     3,024 ops/sec @ 330μs/op ±  92.03% (min: 179μs, max:   1ms)
-------------------------------------------------------------------------------------------------------
many iterations, small buffer, native x 7,246,376 ops/sec @ 138ns/op ±   4.79% (min:  89ns, max:  48μs)
many iterations, small buffer, js     x 9,803,921 ops/sec @ 102ns/op ±  18.42% (min:  57ns, max: 182μs)
-------------------------------------------------------------------------------------------------------
many iterations, large buffer, native x    54,297 ops/sec @  18μs/op
many iterations, large buffer, js     x     5,673 ops/sec @ 176μs/op
```

Here's what the terminal colors look like:

![image](https://github.com/user-attachments/assets/bea4322c-c9af-42c7-bf34-a80fdc22d3c2)

So it looks like the JS<->C++ switching cost is most noticeable with many small inputs (many iterations, small buffer), once the JIT has had time to optimize the code. I'm not totally sure the JIT didn't notice that the input data was the same every time and decided to return a constant; pretty difficult to tell. But i think the more important result is that the native code outperforms the JS code in most cases. In the many iterations, large buffer case, the situation I would argue that performance is the most critical, the improvement is about an order of magnitude.

This uses https://github.com/paulmillr/micro-bmark , which seemed suitable for this use case. I'm using node `v20.15.1`.