### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/brianloveswords/buffer-crc32",
   "repository": {
     "type": "git",
-    "url": "git://github.com/brianloveswords/buffer-crc32.git"
+    "url": "git+https://github.com/brianloveswords/buffer-crc32.git"
   },
   "scripts": {
     "test": "tap tests/*.test.js --reporter classic",


### PR DESCRIPTION
## Summary

Update the package repository metadata from the legacy unauthenticated `git://` GitHub URL to the public HTTPS Git URL.

Before:

```json
"url": "git://github.com/brianloveswords/buffer-crc32.git"
```

After:

```json
"url": "git+https://github.com/brianloveswords/buffer-crc32.git"
```

This is metadata-only: no runtime code, dependency, lockfile, entrypoint, export, type, license, or package-file changes.

## Verification

```sh
node -e "const p=require('./package.json'); if (p.name !== 'buffer-crc32' || p.repository.url !== 'git+https://github.com/brianloveswords/buffer-crc32.git' || p.license !== 'MIT') process.exit(1)"
git diff --check
npm pack --dry-run --ignore-scripts --json .
```

The dry-run package still contains the same package files: `LICENSE`, `README.md`, `index.d.ts`, and `package.json`.
